### PR TITLE
fix(notes): correct addNote sort-order check

### DIFF
--- a/src/slicers/notesSlice.ts
+++ b/src/slicers/notesSlice.ts
@@ -52,7 +52,7 @@ const notesSlice = createSlice({
       const idx = state.items.findIndex((n) => n.id === action.payload.id);
 
       if (idx === -1) {
-        if (state.filters?.order || "desc") {
+        if ((state.filters?.order ?? "desc") === "desc") {
           state.items.unshift(action.payload);
         } else {
           state.items.push(action.payload);


### PR DESCRIPTION
## Summary

Fixes the always-truthy condition in the `addNote` reducer in `src/slicers/notesSlice.ts`. New notes now respect the active sort order: they are prepended when `order` is `desc` and appended when `order` is `asc`.

Closes #18

## Changes

- `src/slicers/notesSlice.ts`: replaced `if (state.filters?.order || "desc")` with `if ((state.filters?.order ?? "desc") === "desc")` so the branch reflects the actual sort order rather than always being truthy.

## Changelog

### Fixed
- New notes are now inserted at the correct position when the list is sorted in ascending order.

## Testing

1. Set the notes sort order to `asc` (oldest first).
2. Create a new note.
3. Verify it is appended at the end of the list (previously it was always prepended).
4. Switch back to `desc` and verify new notes are still prepended at the top.