### PR TITLE
chore(eslint): port config to flat config and apply safe auto-fixes

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,30 +1,65 @@
 // https://docs.expo.dev/guides/using-eslint/
+// ESLint 9 flat config.
 const { defineConfig } = require("eslint/config");
 const expoConfig = require("eslint-config-expo/flat");
+const reactPlugin = require("eslint-plugin-react");
+const tsPlugin = require("@typescript-eslint/eslint-plugin");
+const tsParser = require("@typescript-eslint/parser");
+const unusedImports = require("eslint-plugin-unused-imports");
+const prettierRecommended = require("eslint-plugin-prettier/recommended");
 
 module.exports = defineConfig([
-  expoConfig,
   {
-    extends: [
-      "plugin:react/recommended",
-      "plugin:@typescript-eslint/recommended",
-      "plugin:@typescript-eslint/eslint-recommended",
-      "plugin:prettier/recommended",
+    ignores: [
+      "next-env.d.ts",
+      ".expo/**",
+      ".vscode/**",
+      "build/**",
+      "dist/**",
+      "node_modules/**",
+      "src/assets/**",
+      "src/generated/**",
+      "src-tauri/**",
+      "*.mjs",
+      "package-lock.json",
+      "**/*.md",
     ],
-    plugins: ["react", "@typescript-eslint", "unused-imports"],
+  },
+  ...expoConfig,
+  reactPlugin.configs.flat.recommended,
+  reactPlugin.configs.flat["jsx-runtime"],
+  {
+    files: ["**/*.{ts,tsx,js,jsx}"],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        ecmaVersion: "latest",
+        sourceType: "module",
+        ecmaFeatures: { jsx: true },
+      },
+    },
+    plugins: {
+      "@typescript-eslint": tsPlugin,
+      "unused-imports": unusedImports,
+    },
+    settings: {
+      react: { version: "detect" },
+    },
     rules: {
-      // Typescript
+      ...tsPlugin.configs["eslint-recommended"].overrides[0].rules,
+      ...tsPlugin.configs.recommended.rules,
+      // TypeScript
       "@typescript-eslint/no-unused-vars": "off",
       "@typescript-eslint/no-empty-function": "off",
       "@typescript-eslint/no-explicit-any": "off",
       "@typescript-eslint/ban-ts-comment": "off",
-      "@typescript-eslint/ban-types": "off",
+      "@typescript-eslint/no-require-imports": "off",
       // React
       "react/prop-types": "off",
       "react/react-in-jsx-scope": "off",
       "react/no-unescaped-entities": "off",
       "react/no-array-index-key": "off",
-      // Unused import
+      // Unused imports
       "unused-imports/no-unused-imports": "error",
       "unused-imports/no-unused-vars": [
         "warn",
@@ -36,17 +71,6 @@ module.exports = defineConfig([
         },
       ],
     },
-    ignores: [
-      "next-env.d.ts",
-      ".expo/*",
-      ".vscode/*",
-      "build/*",
-      "dist/*",
-      "node_modules/*",
-      "src/assets/*",
-      "*.mjs",
-      "package-lock.json",
-      "*.md",
-    ],
   },
+  prettierRecommended,
 ]);

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -10,7 +10,6 @@ import { useTheme } from "@react-navigation/native";
 import * as Sentry from "@sentry/react-native";
 import { Stack } from "expo-router";
 import { StatusBar } from "expo-status-bar";
-import React from "react";
 import { I18nextProvider } from "react-i18next";
 import { Platform } from "react-native";
 import { KeyboardProvider } from "react-native-keyboard-controller";

--- a/src/app/categories/change.tsx
+++ b/src/app/categories/change.tsx
@@ -1,5 +1,5 @@
 import { useLocalSearchParams } from "expo-router";
-import React, { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import { CheckIcon } from "react-native-heroicons/outline";

--- a/src/app/categories/create.tsx
+++ b/src/app/categories/create.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import { useCallback, useState } from "react";
 import { useLocalSearchParams } from "expo-router";
 import { useTranslation } from "react-i18next";
 import { Platform, ScrollView, StyleSheet, Text, View } from "react-native";

--- a/src/app/categories/organize.tsx
+++ b/src/app/categories/organize.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { BackHandler, StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import { CheckIcon, PencilSquareIcon, XMarkIcon } from "react-native-heroicons/outline";
@@ -43,8 +43,8 @@ export default function OrganizeCategoriesScreen() {
 
   const saveCategoryOrganization = () => {
     if (orderedCategories.notNumberedCategoryList.length == 0) {
-      let orderedList = [...orderedCategories.reorganizedCategoryList];
-      for (var i = 0; i < orderedList.length; i++) {
+      const orderedList = [...orderedCategories.reorganizedCategoryList];
+      for (let i = 0; i < orderedList.length; i++) {
         orderedList[i] = { ...orderedList[i], order: i };
       }
       dispatch(setCategories({ categories: orderedList, reorder: true }));

--- a/src/app/home.tsx
+++ b/src/app/home.tsx
@@ -204,6 +204,7 @@ export default function HomeScreen() {
     const backHandler = BackHandler.addEventListener("hardwareBackPress", backAction);
 
     return () => backHandler.remove();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isDeleteMode]);
 
   // vibration feedback when deleteMode
@@ -230,6 +231,7 @@ export default function HomeScreen() {
         });
       }
     });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // reset states
@@ -290,6 +292,7 @@ export default function HomeScreen() {
         easing: Easing.inOut(Easing.ease),
       });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isDeleteMode]);
 
   // changelog for new version
@@ -310,6 +313,7 @@ export default function HomeScreen() {
     };
 
     checkVersion();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // filters

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -63,6 +63,7 @@ export default function LoadingScreen() {
     };
 
     runInitialActions();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {

--- a/src/app/index.web.tsx
+++ b/src/app/index.web.tsx
@@ -54,6 +54,7 @@ export default function LoadingScreen() {
     };
 
     runInitialActions();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {

--- a/src/app/intro.tsx
+++ b/src/app/intro.tsx
@@ -2,7 +2,7 @@ import SafeAreaView from "@/components/SafeAreaView";
 import { BORDER, COLOR, FONTSIZE, FONTWEIGHT, PADDING_MARGIN } from "@/constants/styles";
 import { useRouter } from "@/hooks/useRouter";
 import Carousel, { Pagination } from "@ontech7/react-native-snap-carousel";
-import React, { useMemo, useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Dimensions, Image, type ImageSourcePropType, StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import { ArrowRightIcon } from "react-native-heroicons/outline";

--- a/src/app/intro.web.tsx
+++ b/src/app/intro.web.tsx
@@ -1,5 +1,5 @@
 import useEmblaCarousel from "embla-carousel-react";
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Dimensions, Image, type ImageSourcePropType, StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import { ArrowRightIcon, ChevronLeftIcon, ChevronRightIcon } from "react-native-heroicons/outline";

--- a/src/app/notes/[noteId].tsx
+++ b/src/app/notes/[noteId].tsx
@@ -62,6 +62,7 @@ export default function NoteScreen() {
     } else {
       return currentNote;
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [noteId, currentCategory]);
 
   useEffect(() => {

--- a/src/app/secret-code.tsx
+++ b/src/app/secret-code.tsx
@@ -1,6 +1,6 @@
 import { useLocalSearchParams } from "expo-router";
 import i18n from "i18next";
-import React, { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { StyleSheet, Text, View } from "react-native";
 import { useDispatch, useSelector } from "react-redux";
@@ -99,6 +99,7 @@ export default function SecretCodeScreen() {
     (codeValue: string) => {
       handleCodeChange(codeValue);
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [phase]
   );
 

--- a/src/app/settings/about-developer.tsx
+++ b/src/app/settings/about-developer.tsx
@@ -1,7 +1,6 @@
 import BackButton from "@/components/buttons/BackButton";
 import SafeAreaView from "@/components/SafeAreaView";
 import { BORDER, COLOR, FONTSIZE, FONTWEIGHT, PADDING_MARGIN, SIZE } from "@/constants/styles";
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { Image, ScrollView, StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import { openUrl } from "@/utils/openUrl";

--- a/src/app/settings/ai-assistant.tsx
+++ b/src/app/settings/ai-assistant.tsx
@@ -52,6 +52,7 @@ export default function AIAssistantScreen() {
     };
 
     checkModel();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedModelId]);
 
   const selectModel = useCallback(

--- a/src/app/settings/cloud-sync/devices.tsx
+++ b/src/app/settings/cloud-sync/devices.tsx
@@ -98,6 +98,7 @@ export default function SyncedDevicesScreen() {
     } else {
       timeoutStates.error.set(true); // if connection is lost
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [netInfo]);
 
   return (

--- a/src/app/settings/developer-options.tsx
+++ b/src/app/settings/developer-options.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { ScrollView, StyleSheet, Switch, Text, View } from "react-native";
 import { ExclamationTriangleIcon } from "react-native-heroicons/outline";

--- a/src/app/settings/general.tsx
+++ b/src/app/settings/general.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { ScrollView, StyleSheet, Text, View } from "react-native";
 

--- a/src/app/settings/information.tsx
+++ b/src/app/settings/information.tsx
@@ -4,7 +4,7 @@ import { configs } from "@/configs";
 import { BORDER, COLOR, FONTSIZE, FONTWEIGHT, PADDING_MARGIN } from "@/constants/styles";
 import { selectorDeveloperMode, setDeveloperMode } from "@/slicers/settingsSlice";
 import { toast } from "@/utils/toast";
-import React, { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { Platform, ScrollView, StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import { useDispatch, useSelector } from "react-redux";

--- a/src/app/settings/report.tsx
+++ b/src/app/settings/report.tsx
@@ -3,7 +3,7 @@ import * as Sentry from "@sentry/react-native";
 import * as Device from "expo-device";
 import * as FileSystem from "expo-file-system";
 import * as ImagePicker from "expo-image-picker";
-import React, { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Image, Platform, ScrollView, StyleSheet, Text, TextInput, TouchableOpacity, View } from "react-native";
 import { CheckIcon, PlusIcon, XMarkIcon } from "react-native-heroicons/outline";

--- a/src/app/settings/setup-secret-code.tsx
+++ b/src/app/settings/setup-secret-code.tsx
@@ -7,7 +7,7 @@ import { addNote } from "@/slicers/notesSlice";
 import type { Note } from "@/types";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import i18n from "i18next";
-import React, { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import { ArrowPathIcon } from "react-native-heroicons/outline";
@@ -67,6 +67,7 @@ export default function SetupSecretCodeScreen() {
     setCode(text);
   }, []);
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const onSubmit = useCallback((codeValue: string) => handleCodeChange(codeValue), [phase]);
 
   const redoInsert = () => {

--- a/src/app/settings/voice-recognition.tsx
+++ b/src/app/settings/voice-recognition.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { ScrollView, StyleSheet, Switch, Text, TouchableOpacity, View } from "react-native";
 import { useDispatch, useSelector } from "react-redux";

--- a/src/app/settings/webhooks.tsx
+++ b/src/app/settings/webhooks.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { configs } from "@/configs";
 import { FlashList } from "@shopify/flash-list";
 import { useTranslation } from "react-i18next";

--- a/src/app/temporary-trash.tsx
+++ b/src/app/temporary-trash.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigation } from "@react-navigation/native";
 import { FlashList } from "@shopify/flash-list";
 import { useTranslation } from "react-i18next";
@@ -81,6 +81,7 @@ export default function TemporaryTrashScreen() {
     const backHandler = BackHandler.addEventListener("hardwareBackPress", backAction);
 
     return () => backHandler.remove();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isDeleteMode]);
 
   // vibration feedback when deleteMode
@@ -107,6 +108,7 @@ export default function TemporaryTrashScreen() {
         });
       }
     });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // reset states

--- a/src/components/LoadingSpinner.tsx
+++ b/src/components/LoadingSpinner.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { ActivityIndicator, Dimensions, StyleSheet, Text, View } from "react-native";
 
 import { COLOR, FONTSIZE, PADDING_MARGIN } from "@/constants/styles";

--- a/src/components/SafeAreaView.tsx
+++ b/src/components/SafeAreaView.tsx
@@ -3,7 +3,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import type { ViewProps } from "react-native";
 
-export interface SafeAreaViewProps extends ViewProps {}
+export type SafeAreaViewProps = ViewProps;
 
 export default function SafeAreaView({ children, ...props }: SafeAreaViewProps) {
   const { top, bottom } = useSafeAreaInsets();

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { StyleSheet, View } from "react-native";
 import { useSelector } from "react-redux";
 

--- a/src/components/VirtualNumberKeyboard.tsx
+++ b/src/components/VirtualNumberKeyboard.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useCallback } from "react";
+import { memo, useCallback } from "react";
 import { Pressable, StyleSheet, Text, View } from "react-native";
 import { BackspaceIcon } from "react-native-heroicons/outline";
 

--- a/src/components/ai/AIEditorActions.tsx
+++ b/src/components/ai/AIEditorActions.tsx
@@ -166,6 +166,7 @@ export default function AIEditorActions({
       duration: isMenuOpen ? ANIM_OPEN : ANIM_CLOSE,
       easing: isMenuOpen ? Easing.out(Easing.cubic) : Easing.in(Easing.cubic),
     });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isMenuOpen]);
 
   // Back button handled by Modal's onRequestClose

--- a/src/components/buttons/AddCategoryButton.tsx
+++ b/src/components/buttons/AddCategoryButton.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { StyleSheet, TouchableOpacity } from "react-native";
 import { FolderPlusIcon } from "react-native-heroicons/outline";
 

--- a/src/components/buttons/AddNoteKanbanButton.tsx
+++ b/src/components/buttons/AddNoteKanbanButton.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import { useEffect, useRef } from "react";
 import { Animated, Easing, StyleSheet, TouchableOpacity } from "react-native";
 import { ViewColumnsIcon } from "react-native-heroicons/outline";
 
@@ -34,6 +34,7 @@ export default function AddNoteKanbanButton({ isDeleteMode, toggleDeleteMode, st
 
   useEffect(() => {
     scaleEventButton();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isDeleteMode]);
 
   return (

--- a/src/components/buttons/AddNoteOverlayButton.tsx
+++ b/src/components/buttons/AddNoteOverlayButton.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { BackHandler, Pressable, StyleSheet, Text, TouchableOpacity, View, type ViewStyle } from "react-native";
 import { PlusIcon } from "react-native-heroicons/outline";
@@ -118,6 +118,7 @@ export default function AddNoteOverlayButton({ isDeleteMode, toggleDeleteMode }:
       duration: showCloseIcon ? ANIMATION_DURATION_OPEN : ANIMATION_DURATION_CLOSE,
       easing: Easing.out(Easing.cubic),
     });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [showCloseIcon]);
 
   useEffect(() => {
@@ -125,6 +126,7 @@ export default function AddNoteOverlayButton({ isDeleteMode, toggleDeleteMode }:
       duration: isOverlayOpen ? ANIMATION_DURATION_OPEN : ANIMATION_DURATION_CLOSE,
       easing: isOverlayOpen ? Easing.out(Easing.cubic) : Easing.in(Easing.cubic),
     });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOverlayOpen]);
 
   const iconAnimatedStyle = useAnimatedStyle(() => ({

--- a/src/components/buttons/AddNoteTextButton.tsx
+++ b/src/components/buttons/AddNoteTextButton.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import { useEffect, useRef } from "react";
 import { Animated, Easing, StyleSheet, TouchableOpacity } from "react-native";
 import { PlusIcon } from "react-native-heroicons/outline";
 
@@ -34,6 +34,7 @@ export default function AddNoteButton({ isDeleteMode, toggleDeleteMode, style = 
 
   useEffect(() => {
     rotateEventButton();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isDeleteMode]);
 
   return (

--- a/src/components/buttons/AddNoteTodoButton.tsx
+++ b/src/components/buttons/AddNoteTodoButton.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import { useEffect, useRef } from "react";
 import { Animated, Easing, StyleSheet, TouchableOpacity } from "react-native";
 import { ListBulletIcon } from "react-native-heroicons/outline";
 
@@ -34,6 +34,7 @@ export default function AddNoteTextButton({ isDeleteMode, toggleDeleteMode, styl
 
   useEffect(() => {
     scaleEventButton();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isDeleteMode]);
 
   return (

--- a/src/components/buttons/BackButton.tsx
+++ b/src/components/buttons/BackButton.tsx
@@ -1,6 +1,5 @@
 import { COLOR } from "@/constants/styles";
 import { useRouter } from "@/hooks/useRouter";
-import React from "react";
 import type { ViewStyle } from "react-native";
 import { Keyboard, TouchableOpacity } from "react-native";
 import { ChevronLeftIcon } from "react-native-heroicons/outline";

--- a/src/components/buttons/CategoryFilterButton.tsx
+++ b/src/components/buttons/CategoryFilterButton.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useEffect, useState } from "react";
+import { memo, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import { ExclamationTriangleIcon, XMarkIcon } from "react-native-heroicons/outline";
@@ -69,6 +69,7 @@ function CategoryFilterButton({ name, index, icon, selected, deleteMode, toggleD
     } else {
       rotate.value = withTiming(0);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [deleteMode]);
 
   return (

--- a/src/components/buttons/CloseButton.tsx
+++ b/src/components/buttons/CloseButton.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { TouchableOpacity } from "react-native";
 import { XMarkIcon } from "react-native-heroicons/outline";
 

--- a/src/components/buttons/DeepSearchButton.tsx
+++ b/src/components/buttons/DeepSearchButton.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { TouchableOpacity } from "react-native";
 import { DocumentMagnifyingGlassIcon } from "react-native-heroicons/outline";
 

--- a/src/components/buttons/DeleteNotesButton.tsx
+++ b/src/components/buttons/DeleteNotesButton.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { TouchableOpacity } from "react-native";
 import { TrashIcon } from "react-native-heroicons/outline";
 

--- a/src/components/buttons/DismissKeyboardButton.tsx
+++ b/src/components/buttons/DismissKeyboardButton.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Keyboard, StyleSheet, TouchableOpacity } from "react-native";
 import { Path, Svg } from "react-native-svg";
 
@@ -17,7 +16,11 @@ export default function DismissKeyboardButton({ showKeyboardDismiss = false, onP
     <TouchableOpacity
       activeOpacity={0.7}
       onPress={() => {
-        !onPress ? Keyboard.dismiss() : onPress();
+        if (onPress) {
+          onPress();
+        } else {
+          Keyboard.dismiss();
+        }
       }}
       style={[styles.dismissKeyboardButton, { display: !showKeyboardDismiss ? "none" : "flex" }, style]}
     >

--- a/src/components/buttons/FavoriteNotesButton.tsx
+++ b/src/components/buttons/FavoriteNotesButton.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { StyleSheet, TouchableOpacity } from "react-native";
 import { StarIcon } from "react-native-heroicons/outline";
 

--- a/src/components/buttons/GeneralSettingsButton.tsx
+++ b/src/components/buttons/GeneralSettingsButton.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { StyleSheet, TouchableOpacity, View } from "react-native";
 import { Cog8ToothIcon } from "react-native-heroicons/outline";
 

--- a/src/components/buttons/HiddenNotesButton.tsx
+++ b/src/components/buttons/HiddenNotesButton.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { StyleSheet, TouchableOpacity } from "react-native";
 import { EyeSlashIcon } from "react-native-heroicons/outline";
 

--- a/src/components/buttons/NoteFiltersButton.tsx
+++ b/src/components/buttons/NoteFiltersButton.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import {

--- a/src/components/buttons/NoteSettingsButton.tsx
+++ b/src/components/buttons/NoteSettingsButton.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import {

--- a/src/components/buttons/ProtectNotesButton.tsx
+++ b/src/components/buttons/ProtectNotesButton.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { StyleSheet, TouchableOpacity } from "react-native";
 import { KeyIcon } from "react-native-heroicons/outline";
 

--- a/src/components/buttons/ReadOnlyNotesButton.tsx
+++ b/src/components/buttons/ReadOnlyNotesButton.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { StyleSheet, TouchableOpacity } from "react-native";
 import { BookOpenIcon } from "react-native-heroicons/outline";
 

--- a/src/components/buttons/ReorganizeButton.tsx
+++ b/src/components/buttons/ReorganizeButton.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { StyleSheet, TouchableOpacity, View } from "react-native";
 import { RectangleGroupIcon } from "react-native-heroicons/outline";
 

--- a/src/components/buttons/RestoreNotesButton.tsx
+++ b/src/components/buttons/RestoreNotesButton.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { StyleSheet, TouchableOpacity } from "react-native";
 import { ArrowPathIcon } from "react-native-heroicons/outline";
 

--- a/src/components/buttons/SaveButton.tsx
+++ b/src/components/buttons/SaveButton.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { StyleSheet, TouchableOpacity } from "react-native";
 import { CheckIcon } from "react-native-heroicons/outline";
 

--- a/src/components/buttons/TemporaryTrashButton.tsx
+++ b/src/components/buttons/TemporaryTrashButton.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { StyleSheet, TouchableOpacity, View } from "react-native";
 import { ArchiveBoxXMarkIcon } from "react-native-heroicons/outline";
 

--- a/src/components/buttons/TrashedNotesSettingsButton.tsx
+++ b/src/components/buttons/TrashedNotesSettingsButton.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { StyleSheet, Text, TouchableOpacity } from "react-native";
 import { ArrowPathIcon, EllipsisVerticalIcon, TrashIcon } from "react-native-heroicons/outline";

--- a/src/components/buttons/UnusedCategoryButton.tsx
+++ b/src/components/buttons/UnusedCategoryButton.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from "react";
+import { memo } from "react";
 import { StyleSheet, TouchableOpacity } from "react-native";
 
 import { BORDER, COLOR, PADDING_MARGIN } from "@/constants/styles";

--- a/src/components/buttons/VoiceRecognitionButton.tsx
+++ b/src/components/buttons/VoiceRecognitionButton.tsx
@@ -88,6 +88,7 @@ export default function VoiceRecognitionButton({ setTranscript, style = {} }: Pr
     return () => {
       deactivateKeepAwake(KEEP_AWAKE_TAG);
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [recognizing]);
 
   const handleStart = async () => {

--- a/src/components/buttons/VoiceRecognitionButton.web.tsx
+++ b/src/components/buttons/VoiceRecognitionButton.web.tsx
@@ -59,6 +59,7 @@ export default function VoiceRecognitionButton({ setTranscript, style = {} }: Pr
         recognitionRef.current.stop();
       }
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectors.continuous, selectors.interimResults]);
 
   useEffect(() => {

--- a/src/components/cards/OrderedCategoryCard.tsx
+++ b/src/components/cards/OrderedCategoryCard.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from "react";
+import { memo } from "react";
 import { useTranslation } from "react-i18next";
 import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
 
@@ -21,7 +21,9 @@ function OrderedCategoryCard({ category, order, selected = false, toggleCategory
   const { index, name, icon } = category;
 
   const onPress = () => {
-    toggleCategory && toggleCategory(category);
+    if (toggleCategory) {
+      toggleCategory(category);
+    }
   };
 
   return (

--- a/src/components/cards/OrganizeCategoryCard.tsx
+++ b/src/components/cards/OrganizeCategoryCard.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import { useSelector } from "react-redux";

--- a/src/components/cards/TrashedNoteCard.tsx
+++ b/src/components/cards/TrashedNoteCard.tsx
@@ -180,11 +180,11 @@ function CountdownDate({ deleteDate, important }: CountdownDateProps) {
 
   const now = new Date().getTime();
 
-  var distance = (deleteDate ?? 0) - now;
+  const distance = (deleteDate ?? 0) - now;
 
-  var days = Math.floor(distance / (1000 * 60 * 60 * 24));
-  var hours = Math.floor((distance % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
-  var minutes = Math.floor((distance % (1000 * 60 * 60)) / (1000 * 60));
+  const days = Math.floor(distance / (1000 * 60 * 60 * 24));
+  const hours = Math.floor((distance % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
+  const minutes = Math.floor((distance % (1000 * 60 * 60)) / (1000 * 60));
 
   return (
     <Text style={[styles.deleteDate, important && styles.deleteDateImportant]}>

--- a/src/components/changelog/ChangelogItem.tsx
+++ b/src/components/changelog/ChangelogItem.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { StyleSheet, Text, View } from "react-native";
 
 import { BORDER, COLOR, FONTSIZE, FONTWEIGHT, PADDING_MARGIN } from "@/constants/styles";

--- a/src/components/icons/DeviceAndroidIcon/index.tsx
+++ b/src/components/icons/DeviceAndroidIcon/index.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Image, View } from "react-native";
 import { DevicePhoneMobileIcon } from "react-native-heroicons/outline";
 

--- a/src/components/icons/DeviceAppleIcon/index.tsx
+++ b/src/components/icons/DeviceAppleIcon/index.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Image, View } from "react-native";
 import { DevicePhoneMobileIcon } from "react-native-heroicons/outline";
 

--- a/src/components/icons/NoCloudIcon.tsx
+++ b/src/components/icons/NoCloudIcon.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { View } from "react-native";
 import CloudIcon from "react-native-heroicons/outline/CloudIcon";
 

--- a/src/components/inputs/CodeInput.tsx
+++ b/src/components/inputs/CodeInput.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { Platform, StyleSheet, Text, View } from "react-native";
 
 import Haptics from "@/libs/haptics";

--- a/src/components/kanban/KanbanCard.tsx
+++ b/src/components/kanban/KanbanCard.tsx
@@ -1,7 +1,7 @@
 import DragIcon from "@/components/icons/DragIcon";
 import Haptics from "@/libs/haptics";
 import { useKanbanDrag } from "@/providers/KanbanDragProvider";
-import React, { useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { Platform, StyleSheet, TextInput, TouchableOpacity, View } from "react-native";
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
 import { XCircleIcon } from "react-native-heroicons/outline";

--- a/src/components/kanban/KanbanColumn.tsx
+++ b/src/components/kanban/KanbanColumn.tsx
@@ -1,6 +1,6 @@
 import { BORDER, COLOR, FONTSIZE, FONTWEIGHT, KANBAN_COLUMN_COLORS, PADDING_MARGIN } from "@/constants/styles";
 import { useKanbanDrag } from "@/providers/KanbanDragProvider";
-import React, { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { ScrollView, StyleSheet, Text, TextInput, TouchableOpacity, View } from "react-native";
 import { ChevronLeftIcon, ChevronRightIcon, PlusIcon, TrashIcon } from "react-native-heroicons/outline";

--- a/src/components/lists/FavoriteCategoryList.tsx
+++ b/src/components/lists/FavoriteCategoryList.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { FlashList } from "@shopify/flash-list";
 import { BackHandler, StyleSheet } from "react-native";
 
@@ -31,6 +31,7 @@ export default function FavoriteCategoryList({ categories }: Props) {
     const backHandler = BackHandler.addEventListener("hardwareBackPress", backAction);
 
     return () => backHandler.remove();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isDeleteMode]);
 
   // vibration feedback when deleteMode

--- a/src/components/lists/OrderedCategoryList.tsx
+++ b/src/components/lists/OrderedCategoryList.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { StyleSheet, View } from "react-native";
 
 import { PADDING_MARGIN } from "@/constants/styles";

--- a/src/components/lists/OrganizeCategoryList.tsx
+++ b/src/components/lists/OrganizeCategoryList.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Platform, StyleSheet, View } from "react-native";
 
 import { PADDING_MARGIN, SIZE } from "@/constants/styles";

--- a/src/components/lottie/LottieAnimation.web.tsx
+++ b/src/components/lottie/LottieAnimation.web.tsx
@@ -1,5 +1,5 @@
 import lottie from "lottie-web";
-import React, { forwardRef, useEffect, useImperativeHandle, useRef } from "react";
+import { forwardRef, useEffect, useImperativeHandle, useRef } from "react";
 import { View } from "react-native";
 
 import type { ViewStyle } from "react-native";
@@ -61,6 +61,7 @@ const LottieView = forwardRef(function LottieView(
         animationRef.current = null;
       }
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {

--- a/src/components/notes/CodeEditorWebView.tsx
+++ b/src/components/notes/CodeEditorWebView.tsx
@@ -86,10 +86,11 @@ const CodeEditorWebView = forwardRef<CodeEditorWebViewRef, Props>(({ initialCode
   }, [readOnly, sendMessage]);
 
   // Compute HTML ONCE on mount — never changes, never causes WebView reload
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+
   const html = useMemo(() => {
     const configScript = `window.__EDITOR_CONFIG__=${JSON.stringify({ code: initialCode, language, readOnly })};`;
     return CODEMIRROR_HTML.replace("window.__EDITOR_CONFIG__=window.__EDITOR_CONFIG__||{};", configScript);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (

--- a/src/components/notes/FindReplaceBar.tsx
+++ b/src/components/notes/FindReplaceBar.tsx
@@ -48,6 +48,7 @@ export default function FindReplaceBar({ visible, onClose, editorRef, plainText,
       setCurrentMatch(0);
       runInEditor(editorRef, `window.getSelection && window.getSelection().removeAllRanges(); true;`);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [visible]);
 
   const countMatches = useCallback(
@@ -196,6 +197,7 @@ export default function FindReplaceBar({ visible, onClose, editorRef, plainText,
       if (count === 0) setCurrentMatch(0);
       else if (currentMatch > count) setCurrentMatch(count);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [plainText]);
 
   if (!visible) return null;

--- a/src/components/notes/NoteCodeEditor.tsx
+++ b/src/components/notes/NoteCodeEditor.tsx
@@ -23,7 +23,7 @@ import { isStringEmpty } from "@/utils/string";
 
 import { webhook } from "@/utils/webhook";
 import { useFocusEffect } from "@react-navigation/native";
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { BackHandler, Keyboard, Platform, ScrollView, StyleSheet, Text, TextInput, TouchableOpacity, View } from "react-native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
@@ -90,6 +90,7 @@ export default function NoteCodeEditor({ initialNote }: Props) {
       locked: note.locked,
       category: { iconId: note.category.icon, name: note.category.name },
     });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isNewlyCreated]);
 
   const updateNoteGlobal = useCallback(

--- a/src/components/notes/NoteKanbanEditor.tsx
+++ b/src/components/notes/NoteKanbanEditor.tsx
@@ -81,6 +81,7 @@ export default function NoteKanbanEditor({ initialNote }: Props) {
         name: note.category.name,
       },
     });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isNewlyCreated]);
 
   const updateNoteGlobal = useCallback(

--- a/src/components/notes/NoteTextEditor.tsx
+++ b/src/components/notes/NoteTextEditor.tsx
@@ -82,6 +82,7 @@ export default function NoteTextEditor({ initialNote }: Props) {
         name: note.category.name,
       },
     });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isNewlyCreated]);
 
   const updateNoteGlobal = useCallback(

--- a/src/components/notes/NoteTodoEditor.tsx
+++ b/src/components/notes/NoteTodoEditor.tsx
@@ -88,6 +88,7 @@ export default function NoteTodoEditor({ initialNote }: Props) {
         name: note.category.name,
       },
     });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isNewlyCreated]);
 
   const updateNoteGlobal = useCallback(
@@ -148,7 +149,7 @@ export default function NoteTodoEditor({ initialNote }: Props) {
 
   const setTextListItem = useCallback(
     (id: string, text: string) => {
-      let mutableList = Object.assign([], note.list);
+      const mutableList = Object.assign([], note.list);
       const index = mutableList.findIndex((todoItem) => todoItem.id === id);
       mutableList[index] = { ...mutableList[index], text: text };
 
@@ -163,7 +164,7 @@ export default function NoteTodoEditor({ initialNote }: Props) {
         return;
       }
 
-      let mutableList = Object.assign([], note.list);
+      const mutableList = Object.assign([], note.list);
       const index = mutableList.findIndex((todoItem: TodoItemType) => todoItem.id === id);
       mutableList[index] = {
         ...mutableList[index],
@@ -383,7 +384,7 @@ export default function NoteTodoEditor({ initialNote }: Props) {
                 }
 
                 let lastItem = note.list[note.list.length - 1];
-                let mutableList = [...note.list];
+                const mutableList = [...note.list];
 
                 if (!lastItem || lastItem.text.trim()) {
                   lastItem = {

--- a/src/components/notes/NoteTodoEditor.web.tsx
+++ b/src/components/notes/NoteTodoEditor.web.tsx
@@ -87,6 +87,7 @@ export default function NoteTodoEditor({ initialNote }: Props) {
         name: note.category.name,
       },
     });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isNewlyCreated]);
 
   const updateNoteGlobal = useCallback(
@@ -145,7 +146,7 @@ export default function NoteTodoEditor({ initialNote }: Props) {
 
   const setTextListItem = useCallback(
     (id: string, text: string) => {
-      let mutableList = Object.assign([], note.list);
+      const mutableList = Object.assign([], note.list);
       const index = mutableList.findIndex((todoItem) => todoItem.id === id);
       mutableList[index] = { ...mutableList[index], text: text };
 
@@ -160,7 +161,7 @@ export default function NoteTodoEditor({ initialNote }: Props) {
         return;
       }
 
-      let mutableList = Object.assign([], note.list);
+      const mutableList = Object.assign([], note.list);
       const index = mutableList.findIndex((todoItem: TodoItemType) => todoItem.id === id);
       mutableList[index] = {
         ...mutableList[index],
@@ -362,7 +363,7 @@ export default function NoteTodoEditor({ initialNote }: Props) {
               }
 
               let lastItem = note.list[note.list.length - 1];
-              let mutableList = [...note.list];
+              const mutableList = [...note.list];
 
               if (!lastItem || lastItem.text.trim()) {
                 lastItem = {

--- a/src/components/renderers/ContextMenu.tsx
+++ b/src/components/renderers/ContextMenu.tsx
@@ -17,7 +17,7 @@ const axisPosition = (oDim: number, wDim: number, tPos: number, tDim: number) =>
     return tPos + tDim - oDim;
   }
   // compute center position
-  let pos = Math.round(tPos + tDim / 2 - oDim / 2);
+  const pos = Math.round(tPos + tDim / 2 - oDim / 2);
   // check top boundary
   if (pos < 0) {
     return 0;

--- a/src/components/settings/Section.tsx
+++ b/src/components/settings/Section.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from "react";
+import { memo } from "react";
 
 import SectionList from "./components/list/SectionList";
 import SectionHeader from "./components/SectionHeader";

--- a/src/components/settings/components/SectionHeader.tsx
+++ b/src/components/settings/components/SectionHeader.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { StyleSheet, Text, View } from "react-native";
 
 import CategoryIcon from "@/components/CategoryIcon";

--- a/src/components/settings/items/advanced/SectionItem_AIAssistant.tsx
+++ b/src/components/settings/items/advanced/SectionItem_AIAssistant.tsx
@@ -1,5 +1,4 @@
 import { BORDER, COLOR, PADDING_MARGIN } from "@/constants/styles";
-import React from "react";
 import { useTranslation } from "react-i18next";
 import type { TextStyle } from "react-native";
 import { Text } from "react-native";

--- a/src/components/settings/items/advanced/SectionItem_ExportImportData.tsx
+++ b/src/components/settings/items/advanced/SectionItem_ExportImportData.tsx
@@ -6,7 +6,7 @@ import { useSecret } from "@/hooks/useSecret";
 import { isSecretPassphraseCorrect } from "@/utils/crypt";
 import { webhook } from "@/utils/webhook";
 import * as Sentry from "@sentry/react-native";
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Keyboard, Platform } from "react-native";
 import CryptoJS from "react-native-crypto-js";
@@ -225,7 +225,7 @@ export default function SectionItem_ExportImportData({ isLast }: Props) {
 
       const encryptedData = CryptoJS.AES.encrypt(JSON.stringify(exportData), secretPassphrase).toString();
 
-      let fileUri = await StorageAccessFramework.createFileAsync(
+      const fileUri = await StorageAccessFramework.createFileAsync(
         permissions.directoryUri,
         `FastMemo_exportedData_${new Date().getTime()}.txt`,
         "text/plain"

--- a/src/components/settings/items/advanced/SectionItem_ShowHidden.tsx
+++ b/src/components/settings/items/advanced/SectionItem_ShowHidden.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { StyleSheet, Switch, Text, View } from "react-native";
 import { useDispatch, useSelector } from "react-redux";

--- a/src/components/settings/items/advanced/SectionItem_VoiceRecognition.tsx
+++ b/src/components/settings/items/advanced/SectionItem_VoiceRecognition.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 
 import SectionItemList_Navigation from "../../components/item/SectionItemList_Navigation";

--- a/src/components/settings/items/advanced/SectionItem_Webhooks.tsx
+++ b/src/components/settings/items/advanced/SectionItem_Webhooks.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 
 import type { TextStyle } from "react-native";

--- a/src/components/settings/items/advanced/SectionItem_WipeData.tsx
+++ b/src/components/settings/items/advanced/SectionItem_WipeData.tsx
@@ -6,7 +6,7 @@ import { wipeCategories } from "@/slicers/categoriesSlice";
 import { wipeNotes } from "@/slicers/notesSlice";
 import { getCloudConnected, selectorWebhook_wipeData } from "@/slicers/settingsSlice";
 import { webhook } from "@/utils/webhook";
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ExclamationTriangleIcon } from "react-native-heroicons/outline";
 import { useDispatch, useSelector } from "react-redux";

--- a/src/components/settings/items/basic/SectionItem_AppLanguage.tsx
+++ b/src/components/settings/items/basic/SectionItem_AppLanguage.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 

--- a/src/components/settings/items/basic/SectionItem_ChangeSecretCode.tsx
+++ b/src/components/settings/items/basic/SectionItem_ChangeSecretCode.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 
 import { useRouter } from "@/hooks/useRouter";

--- a/src/components/settings/items/basic/SectionItem_CloudSync.tsx
+++ b/src/components/settings/items/basic/SectionItem_CloudSync.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 
 import SectionItemList_Navigation from "../../components/item/SectionItemList_Navigation";

--- a/src/components/settings/items/basic/SectionItem_EnableFingerprint.tsx
+++ b/src/components/settings/items/basic/SectionItem_EnableFingerprint.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import * as LocalAuthentication from "expo-local-authentication";
 import { useTranslation } from "react-i18next";
 import { StyleSheet, Switch, Text, View } from "react-native";

--- a/src/components/settings/items/basic/SectionItem_TemporaryTrash.tsx
+++ b/src/components/settings/items/basic/SectionItem_TemporaryTrash.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 

--- a/src/components/settings/items/feedback/SectionItem_Help.tsx
+++ b/src/components/settings/items/feedback/SectionItem_Help.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 
 import SectionItemList_Navigation from "../../components/item/SectionItemList_Navigation";

--- a/src/components/settings/items/feedback/SectionItem_Report.tsx
+++ b/src/components/settings/items/feedback/SectionItem_Report.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 
 import SectionItemList_Navigation from "../../components/item/SectionItemList_Navigation";

--- a/src/components/settings/items/feedback/SectionItem_Suggest.tsx
+++ b/src/components/settings/items/feedback/SectionItem_Suggest.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { configs } from "@/configs";
 import { useTranslation } from "react-i18next";
 import { Platform, Share } from "react-native";

--- a/src/components/settings/items/info/SectionItem_AppInfo.tsx
+++ b/src/components/settings/items/info/SectionItem_AppInfo.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 
 import SectionItemList_Navigation from "../../components/item/SectionItemList_Navigation";

--- a/src/components/settings/items/info/SectionItem_Changelog.tsx
+++ b/src/components/settings/items/info/SectionItem_Changelog.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 
 import SectionItemList_Navigation from "../../components/item/SectionItemList_Navigation";

--- a/src/components/settings/items/info/SectionItem_DeveloperInfo.tsx
+++ b/src/components/settings/items/info/SectionItem_DeveloperInfo.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 
 import SectionItemList_Navigation from "../../components/item/SectionItemList_Navigation";

--- a/src/components/settings/items/info/SectionItem_DeveloperOptions.tsx
+++ b/src/components/settings/items/info/SectionItem_DeveloperOptions.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 

--- a/src/components/todo/TodoItem.native.tsx
+++ b/src/components/todo/TodoItem.native.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Platform, StyleSheet, TextInput, TouchableOpacity, View } from "react-native";
 import { CheckIcon, XCircleIcon } from "react-native-heroicons/outline";
 

--- a/src/components/webhook/WebhookItem.tsx
+++ b/src/components/webhook/WebhookItem.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Platform, StyleSheet, Text, TextInput, TouchableOpacity, View } from "react-native";
 import { CheckIcon } from "react-native-heroicons/outline";
 

--- a/src/hooks/useCloudSync.ts
+++ b/src/hooks/useCloudSync.ts
@@ -257,6 +257,7 @@ export const useCloudSync = () => {
     };
 
     asyncHandshake();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isConnecting]);
 
   return {

--- a/src/libs/ai/index.web.ts
+++ b/src/libs/ai/index.web.ts
@@ -6,11 +6,11 @@
  * platform-agnostic and re-exported as-is.
  */
 
+import type { AIModelId, AIModelStatus, EditorActionResult } from "./types";
+
 export { findCategoryByName, stripHtml } from "./helpers";
 export { AI_MODELS, DEFAULT_MODEL_ID } from "./constants";
 export type { AIModelStatus, AIModelId, AIModelInfo, EditorAction, EditorActionResult } from "./types";
-
-import type { AIModelId, AIModelStatus, EditorActionResult } from "./types";
 
 // --- no-op stubs for context.ts functions (native-only) ---
 

--- a/src/libs/firebase.ts
+++ b/src/libs/firebase.ts
@@ -215,7 +215,11 @@ export const handshakeFirebase = async (setterCallback: (state: HandshakeState) 
 
     clearTimeout(t);
 
-    isHandshakeSuccess ? ok() : ko();
+    if (isHandshakeSuccess) {
+      ok();
+    } else {
+      ko();
+    }
   } catch (e) {
     console.log(e);
 

--- a/src/providers/KanbanDragProvider.tsx
+++ b/src/providers/KanbanDragProvider.tsx
@@ -1,5 +1,5 @@
 import type { KanbanColumn, KanbanItem } from "@/types";
-import React, { createContext, useCallback, useContext, useRef, useState } from "react";
+import { createContext, useCallback, useContext, useRef, useState } from "react";
 import type { ReactNode, RefObject } from "react";
 import type { ScrollView } from "react-native";
 import { useSharedValue } from "react-native-reanimated";
@@ -112,6 +112,7 @@ export default function KanbanDragProvider({
       dragX.value = cardX;
       dragY.value = cardY;
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     []
   );
 
@@ -141,6 +142,7 @@ export default function KanbanDragProvider({
       lastTargetColumnRef.current = newTargetColumnId;
       setTargetColumnId(newTargetColumnId);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const getTargetColumn = useCallback(
@@ -238,6 +240,7 @@ export default function KanbanDragProvider({
   const setOverlayOffset = useCallback((x: number, y: number) => {
     containerOffsetX.value = x || 0;
     containerOffsetY.value = y || 0;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const value: KanbanDragContextValue = {

--- a/src/providers/SyncOnProvider.tsx
+++ b/src/providers/SyncOnProvider.tsx
@@ -1,5 +1,4 @@
 import useNetInfo from "@/hooks/useNetInfo";
-import type { Category, Note } from "@/types";
 import { isEmpty, isObjectEmpty } from "@/utils/string";
 import { where } from "firebase/firestore";
 import { useCallback, useEffect, useMemo, useRef } from "react";
@@ -241,6 +240,7 @@ export default function SyncOnProvider(): null {
     };
 
     syncCategoriesToCloud();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isCloudConnected, netInfo, cloudCategories_add, cloudCategories_delete]);
 
   ///////////////////////////////////
@@ -301,6 +301,7 @@ export default function SyncOnProvider(): null {
     return () => {
       if (tDebounceNotes.current) clearTimeout(tDebounceNotes.current);
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isCloudConnected, netInfo, cloudNotes_add, cloudNotes_delete]);
 
   return null;


### PR DESCRIPTION
## Summary

`npm run lint` was broken on `dev`: the ESLint 9 flat config file referenced plugins via the legacy `"plugin:react/recommended"` extends syntax, which ESLint 9 no longer resolves (`TypeError: Plugin "plugin:react" not found.`). This PR ports the config to a proper flat config, then applies `--fix` and a small set of manual corrections so the linter runs cleanly end-to-end.

## Changes

### `eslint.config.js`
- Rewrote as a proper flat config: plugins are imported directly (`eslint-plugin-react`, `@typescript-eslint/eslint-plugin`, `@typescript-eslint/parser`, `eslint-plugin-unused-imports`, `eslint-plugin-prettier/recommended`) instead of legacy `extends` strings.
- Use `react.configs.flat.recommended` + `react.configs.flat["jsx-runtime"]` so the `React` import is no longer required (React 19 with automatic JSX runtime).
- Added explicit `ignores` block (expanded to include `src/generated/**` and `src-tauri/**`).
- Kept the same project rule tuning that was in the old config.

### Safe auto-fixes (`eslint --fix`)
- Removed unused `import React from "react"` across ~60 files (React 19 auto JSX runtime + plugin:react/jsx-runtime).
- `let` → `const` where no reassignment (`unused-imports/no-unused-vars` style + prefer-const).
- Reordered imports that were after the top of file (`import/first`).
- Prettier formatting.

### Manual fixes (4 pre-existing errors)
- `src/components/SafeAreaView.tsx` — replace empty extending `interface` with `type` alias (`@typescript-eslint/no-empty-object-type`).
- `src/components/buttons/DismissKeyboardButton.tsx`, `src/components/cards/OrderedCategoryCard.tsx`, `src/libs/firebase.ts` — replace ternary-as-statement with `if/else` (`@typescript-eslint/no-unused-expressions`).

### `react-hooks/exhaustive-deps` triage
I went through each of the 39 violations one by one. 37 are intentional and are now suppressed with a targeted `// eslint-disable-next-line react-hooks/exhaustive-deps` placed above the dependency array line. The intentional categories:

- Animation shared values (reanimated `useSharedValue`): these are stable refs, the rule can't see it.
- Mount-only effects (`[]`) for bootstrap, handshake, back-handler, Lottie setup, auto-focus.
- One-shot webhook firing gated by `isNewlyCreated` in `Note*Editor` components.
- Callbacks that should deliberately capture a subset of state (`onSubmit`/handlers with `[phase]` etc).
- `dispatch` and `editorRef` that are stable by design but flagged as missing.
- Explicit "never-reload" `useMemo([])` in `CodeEditorWebView.tsx` (comment in source confirms intent).

**Two warnings are NOT suppressed** because they look like real stale-closure bugs that deserve a proper fix, not a silence:
- `src/components/ai/AIEditorActions.tsx:251` — `handleAction` useCallback misses `noteTitle`, which is injected into the AI prompt. If the user changes the title while the callback is memoized, the AI runs on the stale title.
- `src/components/inputs/CodeInput.tsx:62` — auto-submit `useEffect` on `[value]` misses `onSubmit`. If the parent passes a new `onSubmit`, the effect keeps calling the old one.

These should be looked at in a follow-up issue.

## Changelog

### Fixed
- Internal: `npm run lint` is runnable again (was broken on `dev` due to ESLint 9 flat config incompatibility).

### Changed
- Internal: removed unused `React` imports throughout the codebase (React 19 JSX runtime does not require them), and several `let` → `const`.

## Testing

- `npx tsc --noEmit` passes with no errors.
- `npm run lint` now runs end-to-end. Before: crash (`TypeError: Plugin "plugin:react" not found.`). After: 0 errors, 81 warnings (47 `eqeqeq`, 18 `unused-imports/no-unused-vars` on unused `(e)` catch vars, 14 `import/no-named-as-default-member`, 2 `react-hooks/exhaustive-deps` left intentionally).
- The remaining warnings are backlog to clean up in follow-up PRs, not regressions introduced here.