### PR TITLE
refactor(imports): enforce @/ alias for cross-module imports

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -70,6 +70,19 @@ module.exports = defineConfig([
           argsIgnorePattern: "^_",
         },
       ],
+      // Enforce @/ alias for cross-module imports.
+      // Same-folder relative imports (./file) are still allowed for co-located files.
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: ["../*"],
+              message: "Use the '@/' path alias for cross-module imports instead of '../' relative paths.",
+            },
+          ],
+        },
+      ],
     },
   },
   prettierRecommended,

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -1,4 +1,4 @@
-import "../styles/global.css";
+import "@/styles/global.css";
 
 import { configs } from "@/configs";
 import { BORDER, COLOR } from "@/constants/styles";

--- a/src/app/categories/create.tsx
+++ b/src/app/categories/create.tsx
@@ -11,13 +11,13 @@ import SafeAreaView from "@/components/SafeAreaView";
 
 import { BORDER, COLOR, FONTSIZE, FONTWEIGHT, PADDING_MARGIN, SIZE } from "@/constants/styles";
 
-import BackButton from "../../components/buttons/BackButton";
-import SaveButton from "../../components/buttons/SaveButton";
-import UnusedCategoryButton from "../../components/buttons/UnusedCategoryButton";
-import BaseInput from "../../components/inputs/BaseInput";
-import { createCategory, getUnusedCategories, updateCategory } from "../../slicers/categoriesSlice";
-import { changeNotesCategory } from "../../slicers/notesSlice";
-import { selectorWebhook_createCategory, selectorWebhook_updateCategory } from "../../slicers/settingsSlice";
+import BackButton from "@/components/buttons/BackButton";
+import SaveButton from "@/components/buttons/SaveButton";
+import UnusedCategoryButton from "@/components/buttons/UnusedCategoryButton";
+import BaseInput from "@/components/inputs/BaseInput";
+import { createCategory, getUnusedCategories, updateCategory } from "@/slicers/categoriesSlice";
+import { changeNotesCategory } from "@/slicers/notesSlice";
+import { selectorWebhook_createCategory, selectorWebhook_updateCategory } from "@/slicers/settingsSlice";
 
 export default function CreateCategoryScreen() {
   const { t } = useTranslation();

--- a/src/app/categories/organize.tsx
+++ b/src/app/categories/organize.tsx
@@ -10,10 +10,10 @@ import SafeAreaView from "@/components/SafeAreaView";
 
 import { COLOR, FONTSIZE, FONTWEIGHT, PADDING_MARGIN, SIZE } from "@/constants/styles";
 
-import AddCategoryButton from "../../components/buttons/AddCategoryButton";
-import BackButton from "../../components/buttons/BackButton";
-import OrganizeCategoryList from "../../components/lists/OrganizeCategoryList";
-import { getCategories, setCategories } from "../../slicers/categoriesSlice";
+import AddCategoryButton from "@/components/buttons/AddCategoryButton";
+import BackButton from "@/components/buttons/BackButton";
+import OrganizeCategoryList from "@/components/lists/OrganizeCategoryList";
+import { getCategories, setCategories } from "@/slicers/categoriesSlice";
 
 export default function OrganizeCategoriesScreen() {
   const { t } = useTranslation();

--- a/src/app/changelog.tsx
+++ b/src/app/changelog.tsx
@@ -6,8 +6,8 @@ import { COLOR, FONTSIZE, FONTWEIGHT, PADDING_MARGIN } from "@/constants/styles"
 import { useEffect, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { Platform, ScrollView, StyleSheet, Text, View } from "react-native";
-import aiLottieJson from "../assets/lottie/AI_Loader.json";
-import lottieJson from "../assets/lottie/Logo.json";
+import aiLottieJson from "@/assets/lottie/AI_Loader.json";
+import lottieJson from "@/assets/lottie/Logo.json";
 
 function getVersionChangelogs(t: (key: string) => string) {
   return Platform.OS === "web"

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -11,7 +11,7 @@ import i18n from "i18next";
 import { useEffect, useRef, useState } from "react";
 import { StyleSheet } from "react-native";
 import Animated, { Easing, runOnJS, useAnimatedStyle, useSharedValue, withTiming } from "react-native-reanimated";
-import lottieJson from "../assets/lottie/Logo_with_Text.json";
+import lottieJson from "@/assets/lottie/Logo_with_Text.json";
 
 export default function LoadingScreen() {
   const router = useRouter();

--- a/src/app/index.web.tsx
+++ b/src/app/index.web.tsx
@@ -9,7 +9,7 @@ import * as Sentry from "@sentry/react-native";
 import i18n from "i18next";
 import { useEffect, useRef, useState } from "react";
 import { StyleSheet, View } from "react-native";
-import lottieJson from "../assets/lottie/Logo_with_Text.json";
+import lottieJson from "@/assets/lottie/Logo_with_Text.json";
 
 export default function LoadingScreen() {
   const router = useRouter();

--- a/src/app/secret-code.tsx
+++ b/src/app/secret-code.tsx
@@ -12,10 +12,10 @@ import { retrieveSecretCodeCallback } from "@/libs/registry";
 
 import { COLOR, FONTSIZE, FONTWEIGHT, PADDING_MARGIN } from "@/constants/styles";
 
-import BackButton from "../components/buttons/BackButton";
-import CodeInput from "../components/inputs/CodeInput";
-import { getNote } from "../slicers/notesSlice";
-import { selectorCurrentSecretCode, setSecretCode } from "../slicers/settingsSlice";
+import BackButton from "@/components/buttons/BackButton";
+import CodeInput from "@/components/inputs/CodeInput";
+import { getNote } from "@/slicers/notesSlice";
+import { selectorCurrentSecretCode, setSecretCode } from "@/slicers/settingsSlice";
 
 const CODE_PHASE = {
   oldCode: i18n.t("secretcode.oldCode"),

--- a/src/app/settings/about-developer.tsx
+++ b/src/app/settings/about-developer.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from "react-i18next";
 import { Image, ScrollView, StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import { openUrl } from "@/utils/openUrl";
 import { ArrowTopRightOnSquareIcon } from "react-native-heroicons/outline";
-import authorImage from "../../assets/images/author.png";
+import authorImage from "@/assets/images/author.png";
 
 const DEVELOPER_NAME = "Andrea Losavio";
 const LINKEDIN_URL = "https://www.linkedin.com/in/andrea-losavio/";

--- a/src/app/settings/information.tsx
+++ b/src/app/settings/information.tsx
@@ -8,9 +8,9 @@ import { useCallback, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { Platform, ScrollView, StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import { useDispatch, useSelector } from "react-redux";
-import BackButton from "../../components/buttons/BackButton";
+import BackButton from "@/components/buttons/BackButton";
 
-import lottieJson from "../../assets/lottie/Logo.json";
+import lottieJson from "@/assets/lottie/Logo.json";
 
 const REACT_VER = "19.0.0";
 const REACT_NATIVE_VER = "0.79.5";

--- a/src/app/settings/report.tsx
+++ b/src/app/settings/report.tsx
@@ -20,7 +20,7 @@ import { formatDateTime } from "@/utils/date";
 
 import { BORDER, COLOR, FONTSIZE, FONTWEIGHT, PADDING_MARGIN, SIZE } from "@/constants/styles";
 
-import lottieJson from "../../assets/lottie/Logo.json";
+import lottieJson from "@/assets/lottie/Logo.json";
 
 interface Attachment {
   filename: string;

--- a/src/app/settings/setup-secret-code.tsx
+++ b/src/app/settings/setup-secret-code.tsx
@@ -12,8 +12,8 @@ import { useTranslation } from "react-i18next";
 import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import { ArrowPathIcon } from "react-native-heroicons/outline";
 import { useDispatch } from "react-redux";
-import CodeInput from "../../components/inputs/CodeInput";
-import { setSecretCode } from "../../slicers/settingsSlice";
+import CodeInput from "@/components/inputs/CodeInput";
+import { setSecretCode } from "@/slicers/settingsSlice";
 
 const CODE_PHASE = {
   firstCode: [i18n.t("setupcode.firstCode_1"), i18n.t("setupcode.firstCode_2")],

--- a/src/app/temporary-trash.tsx
+++ b/src/app/temporary-trash.tsx
@@ -12,17 +12,17 @@ import SafeAreaView from "@/components/SafeAreaView";
 
 import { COLOR, FONTSIZE, FONTWEIGHT, PADDING_MARGIN } from "@/constants/styles";
 
-import BackButton from "../components/buttons/BackButton";
-import TrashedNotesSettingsButton from "../components/buttons/TrashedNotesSettingsButton";
-import TrashedNoteCard from "../components/cards/TrashedNoteCard";
-import SearchNotesInput from "../components/inputs/SearchNotesInput";
-import { deleteNote, getTrashedNotesFilteredPerCategory } from "../slicers/notesSlice";
+import BackButton from "@/components/buttons/BackButton";
+import TrashedNotesSettingsButton from "@/components/buttons/TrashedNotesSettingsButton";
+import TrashedNoteCard from "@/components/cards/TrashedNoteCard";
+import SearchNotesInput from "@/components/inputs/SearchNotesInput";
+import { deleteNote, getTrashedNotesFilteredPerCategory } from "@/slicers/notesSlice";
 import {
   selectorDeveloperMode,
   selectorIsFingerprintEnabled,
   selectorShowHidden,
   selectorWebhook_deleteNote,
-} from "../slicers/settingsSlice";
+} from "@/slicers/settingsSlice";
 
 export default function TemporaryTrashScreen() {
   const { t } = useTranslation();

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -3,7 +3,7 @@ import { useSelector } from "react-redux";
 
 import { BORDER, COLOR, PADDING_MARGIN, SIZE } from "@/constants/styles";
 
-import { getCategories } from "../slicers/categoriesSlice";
+import { getCategories } from "@/slicers/categoriesSlice";
 import GeneralSettingsButton from "./buttons/GeneralSettingsButton";
 import ReorganizeButton from "./buttons/ReorganizeButton";
 import TemporaryTrashButton from "./buttons/TemporaryTrashButton";

--- a/src/components/buttons/CategoryFilterButton.tsx
+++ b/src/components/buttons/CategoryFilterButton.tsx
@@ -16,11 +16,11 @@ import { webhook } from "@/utils/webhook";
 
 import { BORDER, COLOR, FONTSIZE, FONTWEIGHT, PADDING_MARGIN } from "@/constants/styles";
 
-import { deleteCategory, swapCategory } from "../../slicers/categoriesSlice";
-import { deleteNotesCategory, resetNotesCategory } from "../../slicers/notesSlice";
-import { selectorWebhook_deleteCategory } from "../../slicers/settingsSlice";
-import CategoryIcon from "../CategoryIcon";
-import ComplexDialog from "../dialogs/ComplexDialog";
+import { deleteCategory, swapCategory } from "@/slicers/categoriesSlice";
+import { deleteNotesCategory, resetNotesCategory } from "@/slicers/notesSlice";
+import { selectorWebhook_deleteCategory } from "@/slicers/settingsSlice";
+import CategoryIcon from "@/components/CategoryIcon";
+import ComplexDialog from "@/components/dialogs/ComplexDialog";
 
 const AnimatedTouchableOpacity = Animated.createAnimatedComponent(TouchableOpacity);
 

--- a/src/components/buttons/NoteSettingsButton.tsx
+++ b/src/components/buttons/NoteSettingsButton.tsx
@@ -25,9 +25,9 @@ import { webhook } from "@/utils/webhook";
 import { BORDER, COLOR, FONTSIZE, FONTWEIGHT, PADDING_MARGIN } from "@/constants/styles";
 
 import { useSecret } from "@/hooks/useSecret";
-import { temporaryDeleteNote } from "../../slicers/notesSlice";
-import { selectorWebhook_temporaryDeleteNote } from "../../slicers/settingsSlice";
-import ContextMenu from "../renderers/ContextMenu";
+import { temporaryDeleteNote } from "@/slicers/notesSlice";
+import { selectorWebhook_temporaryDeleteNote } from "@/slicers/settingsSlice";
+import ContextMenu from "@/components/renderers/ContextMenu";
 
 import type { Note, TextNote } from "@/types";
 

--- a/src/components/buttons/TrashedNotesSettingsButton.tsx
+++ b/src/components/buttons/TrashedNotesSettingsButton.tsx
@@ -10,16 +10,11 @@ import { webhook } from "@/utils/webhook";
 import { BORDER, COLOR, FONTWEIGHT, PADDING_MARGIN } from "@/constants/styles";
 
 import { useSecret } from "@/hooks/useSecret";
-import { getCategories } from "../../slicers/categoriesSlice";
-import {
-  deleteAllNotes,
-  deleteSelectedNotes,
-  restoreAllTrashedNotes,
-  restoreSelectedTrashedNotes,
-} from "../../slicers/notesSlice";
-import { selectorWebhook_deleteNote, selectorWebhook_restoreNote } from "../../slicers/settingsSlice";
-import ConfirmOrCancelDialog from "../dialogs/ConfirmOrCancelDialog";
-import ContextMenu from "../renderers/ContextMenu";
+import { getCategories } from "@/slicers/categoriesSlice";
+import { deleteAllNotes, deleteSelectedNotes, restoreAllTrashedNotes, restoreSelectedTrashedNotes } from "@/slicers/notesSlice";
+import { selectorWebhook_deleteNote, selectorWebhook_restoreNote } from "@/slicers/settingsSlice";
+import ConfirmOrCancelDialog from "@/components/dialogs/ConfirmOrCancelDialog";
+import ContextMenu from "@/components/renderers/ContextMenu";
 
 interface Props {
   selectedNotes: string[];

--- a/src/components/buttons/UnusedCategoryButton.tsx
+++ b/src/components/buttons/UnusedCategoryButton.tsx
@@ -3,7 +3,7 @@ import { StyleSheet, TouchableOpacity } from "react-native";
 
 import { BORDER, COLOR, PADDING_MARGIN } from "@/constants/styles";
 
-import CategoryIcon from "../CategoryIcon";
+import CategoryIcon from "@/components/CategoryIcon";
 
 interface Props {
   name: string;

--- a/src/components/cards/NoteCard.tsx
+++ b/src/components/cards/NoteCard.tsx
@@ -10,7 +10,7 @@ import { isStringEmpty } from "@/utils/string";
 import { BORDER, COLOR, FONTSIZE, FONTWEIGHT, PADDING_MARGIN } from "@/constants/styles";
 
 import { useSecret } from "@/hooks/useSecret";
-import CategoryIcon from "../CategoryIcon";
+import CategoryIcon from "@/components/CategoryIcon";
 
 import type { Note } from "@/types";
 

--- a/src/components/cards/OrderedCategoryCard.tsx
+++ b/src/components/cards/OrderedCategoryCard.tsx
@@ -4,7 +4,7 @@ import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
 
 import { BORDER, COLOR, FONTSIZE, FONTWEIGHT, PADDING_MARGIN, SIZE } from "@/constants/styles";
 
-import CategoryIcon from "../CategoryIcon";
+import CategoryIcon from "@/components/CategoryIcon";
 
 import type { Category } from "@/types";
 

--- a/src/components/cards/OrganizeCategoryCard.tsx
+++ b/src/components/cards/OrganizeCategoryCard.tsx
@@ -6,8 +6,8 @@ import { useRouter } from "@/hooks/useRouter";
 
 import { BORDER, COLOR, FONTSIZE, FONTWEIGHT, PADDING_MARGIN, SIZE } from "@/constants/styles";
 
-import { getNotesSizePerCategory } from "../../slicers/notesSlice";
-import CategoryIcon from "../CategoryIcon";
+import { getNotesSizePerCategory } from "@/slicers/notesSlice";
+import CategoryIcon from "@/components/CategoryIcon";
 
 import type { Category } from "@/types";
 

--- a/src/components/cards/TrashedNoteCard.tsx
+++ b/src/components/cards/TrashedNoteCard.tsx
@@ -10,11 +10,11 @@ import { webhook } from "@/utils/webhook";
 
 import { BORDER, COLOR, FONTSIZE, FONTWEIGHT, PADDING_MARGIN } from "@/constants/styles";
 
-import { getCategories } from "../../slicers/categoriesSlice";
-import { restoreNote } from "../../slicers/notesSlice";
-import { selectorWebhook_restoreNote } from "../../slicers/settingsSlice";
-import CategoryIcon from "../CategoryIcon";
-import ConfirmOrCancelDialog from "../dialogs/ConfirmOrCancelDialog";
+import { getCategories } from "@/slicers/categoriesSlice";
+import { restoreNote } from "@/slicers/notesSlice";
+import { selectorWebhook_restoreNote } from "@/slicers/settingsSlice";
+import CategoryIcon from "@/components/CategoryIcon";
+import ConfirmOrCancelDialog from "@/components/dialogs/ConfirmOrCancelDialog";
 
 import type { Note } from "@/types";
 

--- a/src/components/inputs/CodeInput.tsx
+++ b/src/components/inputs/CodeInput.tsx
@@ -5,7 +5,7 @@ import Haptics from "@/libs/haptics";
 
 import { BORDER, COLOR, FONTSIZE, FONTWEIGHT, PADDING_MARGIN } from "@/constants/styles";
 
-import VirtualNumberKeyboard from "../VirtualNumberKeyboard";
+import VirtualNumberKeyboard from "@/components/VirtualNumberKeyboard";
 
 const separate = (string: string) => string.split("");
 

--- a/src/components/lists/FavoriteCategoryList.tsx
+++ b/src/components/lists/FavoriteCategoryList.tsx
@@ -4,7 +4,7 @@ import { BackHandler, StyleSheet } from "react-native";
 
 import Haptics from "@/libs/haptics";
 
-import CategoryFilterButton from "../buttons/CategoryFilterButton";
+import CategoryFilterButton from "@/components/buttons/CategoryFilterButton";
 
 import type { Category } from "@/types";
 

--- a/src/components/lists/OrderedCategoryList.tsx
+++ b/src/components/lists/OrderedCategoryList.tsx
@@ -2,7 +2,7 @@ import { StyleSheet, View } from "react-native";
 
 import { PADDING_MARGIN } from "@/constants/styles";
 
-import OrderedCategoryCard from "../cards/OrderedCategoryCard";
+import OrderedCategoryCard from "@/components/cards/OrderedCategoryCard";
 
 import type { Category } from "@/types";
 

--- a/src/components/lists/OrganizeCategoryList.tsx
+++ b/src/components/lists/OrganizeCategoryList.tsx
@@ -2,7 +2,7 @@ import { Platform, StyleSheet, View } from "react-native";
 
 import { PADDING_MARGIN, SIZE } from "@/constants/styles";
 
-import OrganizeCategoryCard from "../cards/OrganizeCategoryCard";
+import OrganizeCategoryCard from "@/components/cards/OrganizeCategoryCard";
 
 import type { Category } from "@/types";
 

--- a/src/components/notes/NoteKanbanEditor.tsx
+++ b/src/components/notes/NoteKanbanEditor.tsx
@@ -25,7 +25,7 @@ import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { KeyboardAvoidingView, KeyboardController } from "react-native-keyboard-controller";
 import { useDispatch, useSelector } from "react-redux";
 import uuid from "react-uuid";
-import KanbanBoard from "../kanban/KanbanBoard";
+import KanbanBoard from "@/components/kanban/KanbanBoard";
 
 const COLUMN_PEEK = 40;
 

--- a/src/components/notes/NoteTodoEditor.web.tsx
+++ b/src/components/notes/NoteTodoEditor.web.tsx
@@ -32,7 +32,7 @@ import uuid from "react-uuid";
 
 import { BORDER, COLOR, FONTSIZE, FONTWEIGHT, PADDING_MARGIN, SIZE } from "@/constants/styles";
 
-import TodoItem from "../todo/TodoItem.web";
+import TodoItem from "@/components/todo/TodoItem.web";
 
 import type { TodoItem as TodoItemType, TodoNote } from "@/types";
 

--- a/src/components/settings/items/advanced/SectionItem_AIAssistant.tsx
+++ b/src/components/settings/items/advanced/SectionItem_AIAssistant.tsx
@@ -2,8 +2,8 @@ import { BORDER, COLOR, PADDING_MARGIN } from "@/constants/styles";
 import { useTranslation } from "react-i18next";
 import type { TextStyle } from "react-native";
 import { Text } from "react-native";
-import SectionItemList_Navigation from "../../components/item/SectionItemList_Navigation";
-import SectionItemList from "../../components/list/SectionItemList";
+import SectionItemList_Navigation from "@/components/settings/components/item/SectionItemList_Navigation";
+import SectionItemList from "@/components/settings/components/list/SectionItemList";
 
 interface Props {
   isLast: boolean;

--- a/src/components/settings/items/advanced/SectionItem_ExportImportData.tsx
+++ b/src/components/settings/items/advanced/SectionItem_ExportImportData.tsx
@@ -12,10 +12,10 @@ import { Keyboard, Platform } from "react-native";
 import CryptoJS from "react-native-crypto-js";
 import { ExclamationTriangleIcon } from "react-native-heroicons/outline";
 import { useDispatch, useStore } from "react-redux";
-import { setCategories } from "../../../../slicers/categoriesSlice";
-import { setNotes, setTrashedNotes } from "../../../../slicers/notesSlice";
-import SectionItemList_Text from "../../components/item/SectionItemList_Text";
-import SectionItemList from "../../components/list/SectionItemList";
+import { setCategories } from "@/slicers/categoriesSlice";
+import { setNotes, setTrashedNotes } from "@/slicers/notesSlice";
+import SectionItemList_Text from "@/components/settings/components/item/SectionItemList_Text";
+import SectionItemList from "@/components/settings/components/list/SectionItemList";
 
 const getFileSystemModules = () => {
   if (Platform.OS === "web") {

--- a/src/components/settings/items/advanced/SectionItem_ShowHidden.tsx
+++ b/src/components/settings/items/advanced/SectionItem_ShowHidden.tsx
@@ -5,8 +5,8 @@ import { useDispatch, useSelector } from "react-redux";
 import { COLOR, FONTSIZE, PADDING_MARGIN } from "@/constants/styles";
 
 import { useSecret } from "@/hooks/useSecret";
-import { selectorShowHidden, setShowHidden } from "../../../../slicers/settingsSlice";
-import SectionItemList from "../../components/list/SectionItemList";
+import { selectorShowHidden, setShowHidden } from "@/slicers/settingsSlice";
+import SectionItemList from "@/components/settings/components/list/SectionItemList";
 
 interface Props {
   isLast: boolean;

--- a/src/components/settings/items/advanced/SectionItem_VoiceRecognition.tsx
+++ b/src/components/settings/items/advanced/SectionItem_VoiceRecognition.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from "react-i18next";
 
-import SectionItemList_Navigation from "../../components/item/SectionItemList_Navigation";
-import SectionItemList from "../../components/list/SectionItemList";
+import SectionItemList_Navigation from "@/components/settings/components/item/SectionItemList_Navigation";
+import SectionItemList from "@/components/settings/components/list/SectionItemList";
 
 interface Props {
   isLast: boolean;

--- a/src/components/settings/items/advanced/SectionItem_Webhooks.tsx
+++ b/src/components/settings/items/advanced/SectionItem_Webhooks.tsx
@@ -4,8 +4,8 @@ import type { TextStyle } from "react-native";
 
 import { BORDER, COLOR, PADDING_MARGIN } from "@/constants/styles";
 
-import SectionItemList_Navigation from "../../components/item/SectionItemList_Navigation";
-import SectionItemList from "../../components/list/SectionItemList";
+import SectionItemList_Navigation from "@/components/settings/components/item/SectionItemList_Navigation";
+import SectionItemList from "@/components/settings/components/list/SectionItemList";
 
 interface Props {
   isLast: boolean;

--- a/src/components/settings/items/advanced/SectionItem_WipeData.tsx
+++ b/src/components/settings/items/advanced/SectionItem_WipeData.tsx
@@ -11,8 +11,8 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ExclamationTriangleIcon } from "react-native-heroicons/outline";
 import { useSelector } from "react-redux";
-import SectionItemList_Text from "../../components/item/SectionItemList_Text";
-import SectionItemList from "../../components/list/SectionItemList";
+import SectionItemList_Text from "@/components/settings/components/item/SectionItemList_Text";
+import SectionItemList from "@/components/settings/components/list/SectionItemList";
 
 interface Props {
   isLast: boolean;

--- a/src/components/settings/items/basic/SectionItem_AppLanguage.tsx
+++ b/src/components/settings/items/basic/SectionItem_AppLanguage.tsx
@@ -6,8 +6,8 @@ import { selectorLanguage } from "@/slicers/settingsSlice";
 import { setLanguageThunk } from "@/slicers/thunks/settings";
 import { useAppDispatch } from "@/slicers/store";
 
-import SectionItemList_Text from "../../components/item/SectionItemList_Text";
-import SectionItemList from "../../components/list/SectionItemList";
+import SectionItemList_Text from "@/components/settings/components/item/SectionItemList_Text";
+import SectionItemList from "@/components/settings/components/list/SectionItemList";
 
 interface Props {
   isLast: boolean;

--- a/src/components/settings/items/basic/SectionItem_ChangeSecretCode.tsx
+++ b/src/components/settings/items/basic/SectionItem_ChangeSecretCode.tsx
@@ -2,8 +2,8 @@ import { useTranslation } from "react-i18next";
 
 import { useRouter } from "@/hooks/useRouter";
 
-import SectionItemList_Text from "../../components/item/SectionItemList_Text";
-import SectionItemList from "../../components/list/SectionItemList";
+import SectionItemList_Text from "@/components/settings/components/item/SectionItemList_Text";
+import SectionItemList from "@/components/settings/components/list/SectionItemList";
 
 interface Props {
   isLast: boolean;

--- a/src/components/settings/items/basic/SectionItem_CloudSync.tsx
+++ b/src/components/settings/items/basic/SectionItem_CloudSync.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from "react-i18next";
 
-import SectionItemList_Navigation from "../../components/item/SectionItemList_Navigation";
-import SectionItemList from "../../components/list/SectionItemList";
+import SectionItemList_Navigation from "@/components/settings/components/item/SectionItemList_Navigation";
+import SectionItemList from "@/components/settings/components/list/SectionItemList";
 
 interface Props {
   isLast: boolean;

--- a/src/components/settings/items/basic/SectionItem_EnableFingerprint.tsx
+++ b/src/components/settings/items/basic/SectionItem_EnableFingerprint.tsx
@@ -5,8 +5,8 @@ import { useDispatch, useSelector } from "react-redux";
 
 import { COLOR, FONTSIZE, PADDING_MARGIN } from "@/constants/styles";
 
-import { selectorIsFingerprintEnabled, setIsFingerprintEnabled } from "../../../../slicers/settingsSlice";
-import SectionItemList from "../../components/list/SectionItemList";
+import { selectorIsFingerprintEnabled, setIsFingerprintEnabled } from "@/slicers/settingsSlice";
+import SectionItemList from "@/components/settings/components/list/SectionItemList";
 
 interface Props {
   isLast: boolean;

--- a/src/components/settings/items/basic/SectionItem_TemporaryTrash.tsx
+++ b/src/components/settings/items/basic/SectionItem_TemporaryTrash.tsx
@@ -1,9 +1,9 @@
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 
-import { getTemporaryTrashTimespan, setTemporaryTrashTimespan } from "../../../../slicers/notesSlice";
-import SectionItemList_Text from "../../components/item/SectionItemList_Text";
-import SectionItemList from "../../components/list/SectionItemList";
+import { getTemporaryTrashTimespan, setTemporaryTrashTimespan } from "@/slicers/notesSlice";
+import SectionItemList_Text from "@/components/settings/components/item/SectionItemList_Text";
+import SectionItemList from "@/components/settings/components/list/SectionItemList";
 
 interface Props {
   isLast: boolean;

--- a/src/components/settings/items/feedback/SectionItem_Help.tsx
+++ b/src/components/settings/items/feedback/SectionItem_Help.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from "react-i18next";
 
-import SectionItemList_Navigation from "../../components/item/SectionItemList_Navigation";
-import SectionItemList from "../../components/list/SectionItemList";
+import SectionItemList_Navigation from "@/components/settings/components/item/SectionItemList_Navigation";
+import SectionItemList from "@/components/settings/components/list/SectionItemList";
 
 interface Props {
   isLast: boolean;

--- a/src/components/settings/items/feedback/SectionItem_Report.tsx
+++ b/src/components/settings/items/feedback/SectionItem_Report.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from "react-i18next";
 
-import SectionItemList_Navigation from "../../components/item/SectionItemList_Navigation";
-import SectionItemList from "../../components/list/SectionItemList";
+import SectionItemList_Navigation from "@/components/settings/components/item/SectionItemList_Navigation";
+import SectionItemList from "@/components/settings/components/list/SectionItemList";
 
 interface Props {
   isLast: boolean;

--- a/src/components/settings/items/feedback/SectionItem_Suggest.tsx
+++ b/src/components/settings/items/feedback/SectionItem_Suggest.tsx
@@ -2,8 +2,8 @@ import { configs } from "@/configs";
 import { useTranslation } from "react-i18next";
 import { Platform, Share } from "react-native";
 
-import SectionItemList_Text from "../../components/item/SectionItemList_Text";
-import SectionItemList from "../../components/list/SectionItemList";
+import SectionItemList_Text from "@/components/settings/components/item/SectionItemList_Text";
+import SectionItemList from "@/components/settings/components/list/SectionItemList";
 
 interface Props {
   isLast: boolean;

--- a/src/components/settings/items/info/SectionItem_AppInfo.tsx
+++ b/src/components/settings/items/info/SectionItem_AppInfo.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from "react-i18next";
 
-import SectionItemList_Navigation from "../../components/item/SectionItemList_Navigation";
-import SectionItemList from "../../components/list/SectionItemList";
+import SectionItemList_Navigation from "@/components/settings/components/item/SectionItemList_Navigation";
+import SectionItemList from "@/components/settings/components/list/SectionItemList";
 
 interface Props {
   isLast: boolean;

--- a/src/components/settings/items/info/SectionItem_Changelog.tsx
+++ b/src/components/settings/items/info/SectionItem_Changelog.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from "react-i18next";
 
-import SectionItemList_Navigation from "../../components/item/SectionItemList_Navigation";
-import SectionItemList from "../../components/list/SectionItemList";
+import SectionItemList_Navigation from "@/components/settings/components/item/SectionItemList_Navigation";
+import SectionItemList from "@/components/settings/components/list/SectionItemList";
 
 interface Props {
   isLast: boolean;

--- a/src/components/settings/items/info/SectionItem_CheckUpdates.tsx
+++ b/src/components/settings/items/info/SectionItem_CheckUpdates.tsx
@@ -5,8 +5,8 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Platform } from "react-native";
 
-import SectionItemList_Navigation from "../../components/item/SectionItemList_Navigation";
-import SectionItemList from "../../components/list/SectionItemList";
+import SectionItemList_Navigation from "@/components/settings/components/item/SectionItemList_Navigation";
+import SectionItemList from "@/components/settings/components/list/SectionItemList";
 
 interface Props {
   isLast: boolean;

--- a/src/components/settings/items/info/SectionItem_DeveloperInfo.tsx
+++ b/src/components/settings/items/info/SectionItem_DeveloperInfo.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from "react-i18next";
 
-import SectionItemList_Navigation from "../../components/item/SectionItemList_Navigation";
-import SectionItemList from "../../components/list/SectionItemList";
+import SectionItemList_Navigation from "@/components/settings/components/item/SectionItemList_Navigation";
+import SectionItemList from "@/components/settings/components/list/SectionItemList";
 
 interface Props {
   isLast: boolean;

--- a/src/components/settings/items/info/SectionItem_DeveloperOptions.tsx
+++ b/src/components/settings/items/info/SectionItem_DeveloperOptions.tsx
@@ -4,8 +4,8 @@ import { useSelector } from "react-redux";
 import { useSecret } from "@/hooks/useSecret";
 import { selectorDeveloperMode } from "@/slicers/settingsSlice";
 
-import SectionItemList_Navigation from "../../components/item/SectionItemList_Navigation";
-import SectionItemList from "../../components/list/SectionItemList";
+import SectionItemList_Navigation from "@/components/settings/components/item/SectionItemList_Navigation";
+import SectionItemList from "@/components/settings/components/list/SectionItemList";
 
 interface Props {
   isLast: boolean;

--- a/src/components/todo/TodoItem.native.tsx
+++ b/src/components/todo/TodoItem.native.tsx
@@ -3,7 +3,7 @@ import { CheckIcon, XCircleIcon } from "react-native-heroicons/outline";
 
 import { BORDER, COLOR, FONTSIZE, FONTWEIGHT, PADDING_MARGIN } from "@/constants/styles";
 
-import DragIcon from "../icons/DragIcon";
+import DragIcon from "@/components/icons/DragIcon";
 
 interface TodoItemData {
   id: string;

--- a/src/components/todo/TodoItem.web.tsx
+++ b/src/components/todo/TodoItem.web.tsx
@@ -6,7 +6,7 @@ import { CheckIcon, XCircleIcon } from "react-native-heroicons/outline";
 
 import { BORDER, COLOR, FONTSIZE, FONTWEIGHT, PADDING_MARGIN } from "@/constants/styles";
 
-import DragIcon from "../icons/DragIcon";
+import DragIcon from "@/components/icons/DragIcon";
 
 interface TodoItemData {
   id: string;

--- a/src/hooks/useCloudSync.ts
+++ b/src/hooks/useCloudSync.ts
@@ -26,8 +26,8 @@ import { getReversedDateTime } from "@/utils/date";
 import { toast } from "@/utils/toast";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 
-import { getCategories, resetCloudCategories, setCategories } from "../slicers/categoriesSlice";
-import { getAllNotes, getNoteFilters, resetCloudNotes, setNotes } from "../slicers/notesSlice";
+import { getCategories, resetCloudCategories, setCategories } from "@/slicers/categoriesSlice";
+import { getAllNotes, getNoteFilters, resetCloudNotes, setNotes } from "@/slicers/notesSlice";
 import {
   getCloudConnected,
   getCloudSettings,
@@ -35,7 +35,7 @@ import {
   setCloudConnected,
   setCloudSettings,
   setIsCloudSyncEnabled,
-} from "../slicers/settingsSlice";
+} from "@/slicers/settingsSlice";
 
 interface ConnectingState {
   loading: boolean;

--- a/src/providers/SyncOnProvider.tsx
+++ b/src/providers/SyncOnProvider.tsx
@@ -7,13 +7,13 @@ import { AppState, Platform } from "react-native";
 import { useSelector } from "react-redux";
 
 import { useAppDispatch } from "@/slicers/store";
-import { COLLECTIONS, getAllDeviceUuids, getAllElementsInCloud, getDeviceUuid, setElementInCloud } from "../libs/firebase";
-import { addLocalCategories, deleteLocalCategories, getCloudCategories } from "../slicers/categoriesSlice";
-import { addLocalNotes, deleteLocalNotes, getCloudNotes } from "../slicers/notesSlice";
-import { getCloudConnected, setCloudConnected, setIsCloudSyncEnabled } from "../slicers/settingsSlice";
-import { addCloudCategoriesAsync, deleteCloudCategoriesAsync } from "../slicers/thunks/categories";
-import { addCloudNotesAsync, deleteCloudNotesAsync } from "../slicers/thunks/notes";
-import { toast } from "../utils/toast";
+import { COLLECTIONS, getAllDeviceUuids, getAllElementsInCloud, getDeviceUuid, setElementInCloud } from "@/libs/firebase";
+import { addLocalCategories, deleteLocalCategories, getCloudCategories } from "@/slicers/categoriesSlice";
+import { addLocalNotes, deleteLocalNotes, getCloudNotes } from "@/slicers/notesSlice";
+import { getCloudConnected, setCloudConnected, setIsCloudSyncEnabled } from "@/slicers/settingsSlice";
+import { addCloudCategoriesAsync, deleteCloudCategoriesAsync } from "@/slicers/thunks/categories";
+import { addCloudNotesAsync, deleteCloudNotesAsync } from "@/slicers/thunks/notes";
+import { toast } from "@/utils/toast";
 
 const PENDING_CHANGES_DELAY = 10000;
 const DEBOUNCE_NOTES_DELAY = 200;

--- a/src/slicers/notesSlice.ts
+++ b/src/slicers/notesSlice.ts
@@ -6,11 +6,11 @@ import type { Category, Note, NoteFilters, NotesState, RootState } from "@/types
 
 import { retrieveDirtyNoteId } from "@/libs/registry";
 
-import { configs } from "../configs";
-import { defaultCategory } from "../configs/default";
-import { only_if_cloudConnected } from "../libs/firebase";
-import { CryptNote } from "../utils/crypt";
-import { createdAt_asc_sort } from "../utils/sort";
+import { configs } from "@/configs";
+import { defaultCategory } from "@/configs/default";
+import { only_if_cloudConnected } from "@/libs/firebase";
+import { CryptNote } from "@/utils/crypt";
+import { createdAt_asc_sort } from "@/utils/sort";
 import { addCloudNotesAsync, deleteCloudNotesAsync, wipeNotes } from "./thunks/notes";
 
 const initialState: NotesState = {


### PR DESCRIPTION
## Summary

Converts all 119 cross-module `../` relative imports across 50 source files to use the `@/` path alias, in line with project conventions. Adds an ESLint rule that blocks future `../` parent-relative imports so the convention is enforced on CI. Pure refactor, no runtime behavior change.

Closes #23

## Changes

- Replaced every cross-module `../...` / `../../...` / `../../../...` import specifier under `src/` with the equivalent `@/...` alias. Same-folder `./sibling` imports are left untouched.
- Added `no-restricted-imports` rule in `eslint.config.js` with pattern `../*` blocking parent-relative imports across module boundaries, with an explanatory message pointing to the `@/` alias.
- Verified the rule empirically: blocks `../`, `../../`, `../../../`, allows `./sibling`.

## Changelog

### Changed
- All cross-module imports now use the `@/` path alias consistently; mixed `../` / `@/` usage in the same file is no longer possible.

## Testing

- `npx tsc --noEmit` -> clean.
- `npm run lint` -> 0 errors, 81 warnings (identical count to `dev`, no regressions).
- `grep -rE "from ['\"]\\.\\./" src` -> no matches (only asset `require("../assets/...")` remain, which are Metro-resolved runtime asset pointers, not module imports).