### PR TITLE
fix(hooks): clear useRouter navigation-guard timeout on unmount

### DIFF
--- a/src/hooks/useRouter.ts
+++ b/src/hooks/useRouter.ts
@@ -1,20 +1,37 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useRouter as useExpoRouter } from "expo-router";
 
 import type { Href } from "expo-router";
 import type { NavigationOptions } from "expo-router/build/global-state/routing";
 
+const NAVIGATION_GUARD_MS = 1000;
+
 export function useRouter() {
   const router = useExpoRouter();
   const [isNavigating, setIsNavigating] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current !== null) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+    };
+  }, []);
 
   const push = (href: Href, options?: NavigationOptions) => {
     if (isNavigating) return;
     setIsNavigating(true);
     router.push(href, options);
-    setTimeout(() => {
+
+    if (timeoutRef.current !== null) {
+      clearTimeout(timeoutRef.current);
+    }
+    timeoutRef.current = setTimeout(() => {
+      timeoutRef.current = null;
       setIsNavigating(false);
-    }, 1000);
+    }, NAVIGATION_GUARD_MS);
   };
 
   return {


### PR DESCRIPTION
## Summary

`useRouter` set `isNavigating = true` and scheduled a `setTimeout` to reset it after 1000ms, but never cleared the timer. If the consuming component unmounted before the timer fired, React logged a state-update-on-unmounted-component warning and the captured closure leaked. Fix by storing the timer id in a ref and clearing it in a `useEffect` cleanup.

Closes #102

## Changes

- `src/hooks/useRouter.ts`: track the navigation-guard `setTimeout` id via `useRef` and clear it on unmount (and defensively before re-scheduling). Extracted the 1000ms literal into a named constant `NAVIGATION_GUARD_MS`. Public API (`push`, `isNavigating`, spread of `router`) is unchanged.

## Changelog

### Fixed
- Cleaned up a pending timer in the navigation hook that could fire after a screen unmounted, removing a potential memory leak and a React state-update-on-unmounted-component warning.

## Testing

- `npx tsc --noEmit` -> clean.
- `npm run lint` -> no new warnings in `src/hooks/useRouter.ts` (pre-existing warnings in other files unchanged).
- Manual: navigate away from a screen that just called `router.push` before the 1000ms guard elapses; no warning is emitted and `isNavigating` does not flip on a stale instance.